### PR TITLE
Comment out erroring line "timezone": "${env.TZ:UTC}" in boxlang.json…

### DIFF
--- a/src/resources/boxlang.json
+++ b/src/resources/boxlang.json
@@ -39,7 +39,7 @@
 	// Please use the IANA timezone database values
 	// On AWS YOU CAN use: ${env.TZ:UTC} to use the environment variable TZ or default to UTC
 	// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
-	"timezone": "${env.TZ:UTC}",
+	//"timezone": "${env.TZ:UTC}",
 	// The default locale for the runtime; defaults to the JVM locale if empty
 	// Please use the IETF BCP 47 language tag values
 	"locale": "",


### PR DESCRIPTION
… as the default value syntax is not supported yet